### PR TITLE
Remove ticket mentioned text, move project settings to env vars

### DIFF
--- a/jira_linker_bot/commands/replace.rb
+++ b/jira_linker_bot/commands/replace.rb
@@ -1,13 +1,13 @@
 module JiraLinkerBot
   module Commands
     class Replace < SlackRubyBot::Commands::Base
-      scan(/(CPIN-\d{1,4})/) do |client, data, tickets|
+      scan(/(#{ENV['JIRA_PROJECT_KEY']}-\d{1,4})/) do |client, data, tickets|
         buttons = []
         links = []
 
         tickets.each do |ticket|
           ticket_number = ticket.first
-          link = "https://continuitypartner.atlassian.net/browse/#{ticket_number}"
+          link = "#{ENV['JIRA_URL']}browse/#{ticket_number}"
 
           buttons << {
             type: 'button',
@@ -18,7 +18,6 @@ module JiraLinkerBot
         end
 
         client.web_client.chat_postMessage(
-          text: 'JIRA ticket(s) mentioned',
           channel: data.channel,
           as_user: true,
           attachments: [


### PR DESCRIPTION
Make app more generic by moving project settings  to env vars `JIRA_PROJECT_KEY` and `JIRA_URL`.
Remove `JIRA ticket(s) mentioned` from the messages on slack as it is obvious information, often repeated and takes space in chat view.